### PR TITLE
[Fix] Use BASE_URL to generate GQL Isomorphic link

### DIFF
--- a/lib/graphql/apollo-client.js
+++ b/lib/graphql/apollo-client.js
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
+import { Constants } from '../../utils'
 
 let apolloClient
 
@@ -47,7 +48,7 @@ function createIsomorphLink(cookie) {
   }
 
   return new HttpLink({
-    uri: `http://localhost:3000/api/gql`,
+    uri: `${Constants.BASE_URL}/api/gql`,
     credentials: 'same-origin',
     fetch: fetchWithCookie,
   })

--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ module.exports = {
     }
 
     if (process.env.APP_ENV && process.env.APP_ENV === 'LOCALHOST') {
-      config.devtool = 'cheap-module-eval-source-map'
+      config.devtool = 'eval-source-map'
     }
 
     // enable top-level await, see pages/api/gql/index.ts for usecase.


### PR DESCRIPTION
`Constants.BASE_URL` is a constant ENV_VARIABLE that Next.JS uses for both client & server. Next.js replaces the `process.env.NEXT_PUBLIC_SITE_URL` text with the ENV_VARIABLE value for client-side.

Also, we switched back to using `eval-source-map` in `next.config.js` because `cheap-module-eval-source-map` doesn't exist in webpack 5, causing some (local) vercel deployment errors.

* Fixes #37